### PR TITLE
Fix login to use Flask backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+__pycache__/
+*.pyc
+.DS_Store
+package-lock.json

--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -1,7 +1,9 @@
-if (!localStorage.getItem('isAuthenticated')) {
+if (!localStorage.getItem('token')) {
     window.location.href = 'admin/login.html';
 }
+
 document.getElementById('logout').addEventListener('click', function () {
+    localStorage.removeItem('token');
     localStorage.removeItem('isAuthenticated');
     window.location.href = 'admin/login.html';
 });

--- a/docs/admin/login.js
+++ b/docs/admin/login.js
@@ -1,13 +1,27 @@
-document.getElementById('login-form').addEventListener('submit', function (event) {
+const form = document.getElementById('login-form');
+form.addEventListener('submit', async function(event) {
     event.preventDefault();
     const username = document.getElementById('username').value;
     const password = document.getElementById('password').value;
     const errorMessage = document.getElementById('error-message');
-    // Пример проверки (замените на серверную авторизацию в продакшене)
-    if (username === 'admin' && password === 'password123') {
+    errorMessage.style.display = 'none';
+
+    try {
+        const response = await fetch('http://localhost:3001/api/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password })
+        });
+
+        if (!response.ok) {
+            throw new Error('Auth failed');
+        }
+
+        const data = await response.json();
+        localStorage.setItem('token', data.token);
         localStorage.setItem('isAuthenticated', 'true');
         window.location.href = '../dashboard.html';
-    } else {
+    } catch (e) {
         errorMessage.style.display = 'block';
     }
 });

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -101,8 +101,8 @@
 <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
 <script src="js/blog-editor.js"></script>
 <script>
-    // Проверка авторизации
-    if (!localStorage.getItem('isAuthenticated')) {
+    // Проверка авторизации через токен
+    if (!localStorage.getItem('token')) {
         window.location.href = 'admin/login.html';
     }
 </script>


### PR DESCRIPTION
## Summary
- ignore `node_modules` and other generated files
- connect login form to Flask `/api/login` endpoint
- check auth token on dashboard and blog editor

## Testing
- `python3 -m py_compile server/app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f634ab2ac8320a980f133aa512c87