### PR TITLE
Implement first-login credential change

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,4 @@
+{
+  "admin": {"password": "admin", "must_change": true},
+  "editor": {"password": "editor123", "must_change": false}
+}

--- a/docs/admin/change-credentials.html
+++ b/docs/admin/change-credentials.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Изменить учетные данные</title>
+    <link rel="stylesheet" href="admin.css">
+</head>
+<body>
+<div class="login-container">
+    <h2>Новые логин и пароль</h2>
+    <form id="change-form">
+        <label for="username">Новый логин:</label>
+        <input type="text" id="username" required>
+        <label for="password">Новый пароль:</label>
+        <input type="password" id="password" required>
+        <button type="submit">Сохранить</button>
+        <p id="error-message" style="color: red; display: none;">Ошибка изменения</p>
+    </form>
+</div>
+<script src="change-credentials.js"></script>
+</body>
+</html>

--- a/docs/admin/change-credentials.js
+++ b/docs/admin/change-credentials.js
@@ -1,0 +1,27 @@
+const form = document.getElementById('change-form');
+form.addEventListener('submit', async function(event) {
+    event.preventDefault();
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    const errorMessage = document.getElementById('error-message');
+    errorMessage.style.display = 'none';
+
+    try {
+        const token = localStorage.getItem('token');
+        const response = await fetch('http://localhost:3001/api/change_credentials', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + token
+            },
+            body: JSON.stringify({ username, password })
+        });
+        if (!response.ok) {
+            throw new Error('Change failed');
+        }
+        localStorage.setItem('token', token);
+        window.location.href = '../dashboard.html';
+    } catch (e) {
+        errorMessage.style.display = 'block';
+    }
+});

--- a/docs/admin/login.js
+++ b/docs/admin/login.js
@@ -20,7 +20,11 @@ form.addEventListener('submit', async function(event) {
         const data = await response.json();
         localStorage.setItem('token', data.token);
         localStorage.setItem('isAuthenticated', 'true');
-        window.location.href = '../dashboard.html';
+        if (data.must_change) {
+            window.location.href = 'change-credentials.html';
+        } else {
+            window.location.href = '../dashboard.html';
+        }
     } catch (e) {
         errorMessage.style.display = 'block';
     }


### PR DESCRIPTION
## Summary
- add a users JSON store for credentials
- update server to load/save users and allow changing credentials
- return `must_change` on login when default password in use
- add change-credentials page and script
- redirect to change page from login when required

## Testing
- `python3 -m py_compile server/app.py`
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683f6666ed788320b26be39dbd394fbe