### PR TITLE
Add README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# My Personal Site
+
+## Installation
+
+Install Python dependencies using pip:
+
+```bash
+pip install -r server/requirements.txt
+```
+
+## Running the Server
+
+Start the Flask server with:
+
+```bash
+python server/app.py
+```
+
+The application will run on port `3001` by default.
+
+## Default Credentials
+
+The project starts with two users defined in `data/users.json`:
+
+- `admin` / `admin`
+- `editor` / `editor123`
+
+The first login as `admin` requires the credentials to be changed. After a successful login with the default `admin` credentials, the browser is redirected to `change-credentials.html`.


### PR DESCRIPTION
## Summary
- add initial README with installation instructions

## Testing
- `python -m py_compile server/app.py`
- `pip install -r server/requirements.txt`
- `python server/app.py & sleep 2; pkill -f server/app.py`


------
https://chatgpt.com/codex/tasks/task_e_683f6be552d08320ac08c1e972c3a1d8