### PR TITLE
Add specific login error handling

### DIFF
--- a/docs/admin/login.js
+++ b/docs/admin/login.js
@@ -14,7 +14,9 @@ form.addEventListener('submit', async function(event) {
         });
 
         if (!response.ok) {
-            throw new Error('Auth failed');
+            const err = new Error('Auth failed');
+            err.status = response.status;
+            throw err;
         }
 
         const data = await response.json();
@@ -26,6 +28,11 @@ form.addEventListener('submit', async function(event) {
             window.location.href = '../dashboard.html';
         }
     } catch (e) {
+        if (e.status === 401) {
+            errorMessage.textContent = 'Неверное имя пользователя или пароль';
+        } else {
+            errorMessage.textContent = 'Не удалось подключиться к серверу';
+        }
         errorMessage.style.display = 'block';
     }
 });


### PR DESCRIPTION
## Summary
- show a different message for unreachable server vs wrong credentials on admin login

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f6be6c5288320bf8937986c31fbd9