### PR TITLE
Serve static front‑end from Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ python server/app.py
 
 The application will run on port `3001` by default.
 
+When running, the Flask server also serves the front-end from the `docs`
+directory. Open `http://localhost:3001/` in your browser to view the site.
+
 ## Default Credentials
 
 The project starts with two users defined in `data/users.json`:

--- a/server/app.py
+++ b/server/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory, abort
 from flask_cors import CORS
 from dotenv import load_dotenv
 import os
@@ -9,7 +9,8 @@ import datetime
 # Загрузка переменных окружения
 load_dotenv()
 
-app = Flask(__name__)
+STATIC_DIR = os.path.join(os.path.dirname(__file__), "../docs")
+app = Flask(__name__, static_folder=STATIC_DIR, static_url_path="")
 CORS(app)
 
 # Секреты из .env
@@ -141,6 +142,20 @@ def change_credentials():
         json.dump(USERS, f, ensure_ascii=False, indent=2)
 
     return jsonify({"success": True})
+
+
+# ==== Раздача статики и HTML ====
+@app.route("/", defaults={"path": "index.html"})
+@app.route("/<path:path>")
+def static_files(path):
+    if path.startswith("api/"):
+        abort(404)
+    full_path = os.path.join(app.static_folder, path)
+    if os.path.isdir(full_path):
+        path = os.path.join(path, "index.html")
+    if not os.path.exists(os.path.join(app.static_folder, path)):
+        path = "index.html"
+    return send_from_directory(app.static_folder, path)
 
 
 # ==== Запуск ====


### PR DESCRIPTION
## Summary
- configure `app.py` to serve HTML/CSS/JS from `docs`
- document the new behaviour in the README

## Testing
- `python -m py_compile server/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68401cb85c648320b9072b09715618ef