### PR TITLE
Fix asset paths in editor

### DIFF
--- a/docs/blog-editor.html
+++ b/docs/blog-editor.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <title>Создать пост</title>
     <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" />
-    <link rel="stylesheet" href="/www/css/base.css" />
-    <link rel="stylesheet" href="/www/css/header.css" />
-    <link rel="stylesheet" href="/www/css/blog.css" />
+    <link rel="stylesheet" href="css/base.css" />
+    <link rel="stylesheet" href="css/header.css" />
+    <link rel="stylesheet" href="css/blog.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
 </head>
 <body class="editor-dark">
@@ -87,7 +87,7 @@
 </div>
 
 <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
-<script src="/www/js/blog-editor.js"></script>
-<script src="/www/js/main.js"></script>
+<script src="js/blog-editor.js"></script>
+<script src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update blog editor HTML to use relative asset paths

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68440939fe60832091d85ded4ef0275f