### PR TITLE
Unify default port to 3001

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Start the Flask server with:
 python server/app.py
 ```
 
-The application will run on port `3001` by default.
+The application will run on port `3001`.
 
 ## Default Credentials
 

--- a/server/app.py
+++ b/server/app.py
@@ -158,4 +158,4 @@ def change_credentials():
 
 # ==== Запуск сервера ====
 if __name__ == "__main__":
-    app.run(host="127.0.0.1", port=5000, debug=True)
+    app.run(host="127.0.0.1", port=3001, debug=True)


### PR DESCRIPTION
## Summary
- set Flask app to run on port 3001
- clarify README about the running port

## Testing
- `python -m py_compile server/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68440d6ff1588320ba3e463665cdea40