### PR TITLE
Update blog posts path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ The project starts with two users defined in `data/users.json`:
 - `editor` / `editor123`
 
 The first login as `admin` requires the credentials to be changed. After a successful login with the default `admin` credentials, the browser is redirected to `change-credentials.html`.
+
+Blog posts are stored in `docs/blog/posts.json` and served by the Flask application.

--- a/server/app.py
+++ b/server/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify, render_template
+from flask import Flask, request, jsonify, render_template, send_from_directory
 from flask_cors import CORS
 from dotenv import load_dotenv
 import os
@@ -18,7 +18,7 @@ JWT_SECRET = os.getenv("JWT_SECRET", "changeme")
 
 # Пути к файлам
 USERS_FILE = os.path.join(os.path.dirname(__file__), "../data/users.json")
-DATA_FILE = os.path.join(os.path.dirname(__file__), "../data/posts.json")
+DATA_FILE = os.path.join(os.path.dirname(__file__), "../docs/blog/posts.json")
 
 # Загрузка или создание пользователей
 if os.path.exists(USERS_FILE):
@@ -95,6 +95,13 @@ def blog_post_2():
 @app.get("/portfolio/work_1")
 def portfolio_work_1():
     return render_template("portfolio/work_1.html")
+
+@app.get("/blog/posts.json")
+def blog_posts_json():
+    return send_from_directory(
+        os.path.join(os.path.dirname(__file__), "../docs/blog"),
+        "posts.json"
+    )
 
 # ==== Логин ====
 @app.post("/api/login")


### PR DESCRIPTION
## Summary
- serve posts.json from the docs directory
- expose `/blog/posts.json` endpoint
- mention the posts.json location in README

## Testing
- `python -m py_compile server/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844294fc0a883208657d31b26dbdd57